### PR TITLE
Fixing app icon bug where view is reused.

### DIFF
--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainListViewAdapter.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainListViewAdapter.java
@@ -2,7 +2,6 @@ package com.PrivacyGuard.Application.Activities;
 
 import java.util.List;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.view.LayoutInflater;
@@ -20,15 +19,16 @@ import com.PrivacyGuard.Application.Logger;
  * Created by MAK on 17/11/2015.
  */
 public class MainListViewAdapter extends BaseAdapter{
-private static final String TAG = MainListViewAdapter.class.getSimpleName();
+    private static final String TAG = MainListViewAdapter.class.getSimpleName();
     private List<AppSummary> list;
     private final Context context;
-    PackageManager pm;
-    public MainListViewAdapter(Context context, List<AppSummary> list){
+    private PackageManager pm;
+
+    public MainListViewAdapter(Context context, List<AppSummary> list) {
         super();
-        this.context=context;
+        this.context = context;
         this.pm = context.getPackageManager();
-        this.list=list;
+        this.list = list;
     }
 
     public void updateData(List<AppSummary> list){
@@ -50,36 +50,34 @@ private static final String TAG = MainListViewAdapter.class.getSimpleName();
         return position;
     }
 
-
     @Override
     public View getView(int position, View convertView, ViewGroup parent) {
         ViewHolder holder;
-        if(convertView == null){
-            LayoutInflater inflater = (LayoutInflater) context
-                    .getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            convertView=inflater.inflate(R.layout.listview_main, null);
+        if (convertView == null) {
+            LayoutInflater inflater = LayoutInflater.from(context);
+            convertView = inflater.inflate(R.layout.listview_main, null);
             holder = new ViewHolder();
-            holder.appIcon = (ImageView) convertView.findViewById(R.id.main_appIcon);
-            holder.appName=(TextView) convertView.findViewById(R.id.main_appName);
-            holder.leakCount=(TextView) convertView.findViewById(R.id.main_leakCount);
+            holder.appIcon = (ImageView)convertView.findViewById(R.id.main_appIcon);
+            holder.appName = (TextView)convertView.findViewById(R.id.main_appName);
+            holder.leakCount = (TextView)convertView.findViewById(R.id.main_leakCount);
             convertView.setTag(holder);
-        }else {
-
-            holder = (ViewHolder) convertView.getTag();
+        } else {
+            holder = (ViewHolder)convertView.getTag();
         }
-        AppSummary app= list.get(position);
+        AppSummary app = list.get(position);
         holder.appName.setText(app.appName);
         holder.leakCount.setText(String.valueOf(app.totalLeaks));
         try {
-            holder.appIcon.setImageDrawable( pm.getApplicationIcon(app.packageName));
+            holder.appIcon.setImageDrawable(pm.getApplicationIcon(app.packageName));
         } catch (PackageManager.NameNotFoundException e) {
+            holder.appIcon.setImageResource(R.drawable.default_icon);
             Logger.w(TAG, e.getMessage());
         }
 
         return convertView;
     }
 
-    public static class ViewHolder {
+    private static class ViewHolder {
         public ImageView appIcon;
         public TextView appName;
         public TextView leakCount;

--- a/app/src/main/res/layout/listview_main.xml
+++ b/app/src/main/res/layout/listview_main.xml
@@ -12,7 +12,6 @@
     <ImageView
         android:layout_width="32dp"
         android:layout_height="32dp"
-        android:src="@drawable/default_icon"
         android:id="@+id/main_appIcon"
         android:scaleType="centerInside"
         android:layout_marginStart="4dp"


### PR DESCRIPTION
The Android ListView will reuse views for efficiency.  Hence, when we populate a view for the ListView, its fields could be populated with values from a previous view.  In the case where an app icon drawable is not found (ie the app was deleted since the leakage incident), we must always reset the app icon to the default app icon.  Otherwise, the app icon field could already be populated by the icon of another app, as seen in the attached example where the "Survey Monkey" app displays the "Google Play Store" icon instead of the default.

![screenshot_2017-01-14-22-26-03](https://cloud.githubusercontent.com/assets/11587125/21960069/654f2f4a-daaa-11e6-84e1-af974ca6d2b6.png)
