### PR TITLE
Fix main activity.

### DIFF
--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
@@ -20,15 +20,18 @@
 package com.PrivacyGuard.Application.Activities;
 
 import android.app.Activity;
+import android.content.BroadcastReceiver;
 import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.content.ServiceConnection;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.VpnService;
 import android.os.Bundle;
 import android.os.Environment;
+import android.os.Handler;
 import android.os.IBinder;
 import android.security.KeyChain;
 import android.util.Log;
@@ -52,8 +55,6 @@ import com.opencsv.CSVWriter;
 
 import java.io.File;
 import java.io.FileWriter;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 
 import javax.security.cert.Certificate;
@@ -65,17 +66,34 @@ public class MainActivity extends Activity {
     private static String TAG = "MainActivity";
     private static final int REQUEST_VPN = 1;
     public static final int REQUEST_CERT = 2;
-    private ArrayList<HashMap<String, String>> list;
 
     private ToggleButton buttonConnect;
     private ListView listLeak;
     private MainListViewAdapter adapter;
     private DatabaseHandler mDbHandler; // [w3kim@uwaterloo.ca] : factored out as an instance var
 
+    private View loadingView;
+    private View contentView;
+
     private boolean bounded = false;
     private boolean keyChainInstalled = false;
     ServiceConnection mSc;
     MyVpnService mVPN;
+
+    private class ReceiveMessages extends BroadcastReceiver {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            final Handler handler = new Handler();
+            handler.postDelayed(new Runnable() {
+                @Override
+                public void run() {
+                    showLoadingView(false);
+                }
+            }, 2000);
+        }
+    }
+    ReceiveMessages myReceiver = null;
+    Boolean myReceiverIsRegistered = false;
 
     /**
      * Called when the activity is first created.
@@ -85,6 +103,11 @@ public class MainActivity extends Activity {
         super.onCreate(savedInstanceState);
 
         setContentView(R.layout.activity_main);
+
+        myReceiver = new ReceiveMessages();
+
+        loadingView = findViewById(R.id.loading_view);
+        contentView = findViewById(R.id.content);
 
         buttonConnect = (ToggleButton) findViewById(R.id.connect_button);
         listLeak = (ListView) findViewById(R.id.leaksList);
@@ -99,7 +122,7 @@ public class MainActivity extends Activity {
                     } else {
                         startVPN();
                     }
-                } else {
+                } else if (!isChecked && MyVpnService.isRunning()) {
                     Logger.d(TAG, "Connect toggled OFF");
                     stopVPN();
                 }
@@ -124,9 +147,12 @@ public class MainActivity extends Activity {
 
         mDbHandler = new DatabaseHandler(this);
         mDbHandler.monthlyReset();
-        installCertificate();
     }
 
+    private void showLoadingView(boolean show) {
+        loadingView.setVisibility(show ? View.VISIBLE : View.GONE);
+        contentView.setVisibility(show ? View.GONE : View.VISIBLE);
+    }
 
     @Override
     protected void onStart() {
@@ -144,6 +170,19 @@ public class MainActivity extends Activity {
         super.onResume();
         populateLeakList();
 
+        if (!myReceiverIsRegistered) {
+            registerReceiver(myReceiver, new IntentFilter("com.PrivacyGuard.VpnRunning"));
+            myReceiverIsRegistered = true;
+        }
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        if (myReceiverIsRegistered) {
+            unregisterReceiver(myReceiver);
+            myReceiverIsRegistered = false;
+        }
     }
 
     @Override
@@ -196,8 +235,9 @@ public class MainActivity extends Activity {
      */
     public void installCertificate() {
         boolean certInstalled = CertificateManager.isCACertificateInstalled(MyVpnService.CADir, MyVpnService.CAName, MyVpnService.KeyType, MyVpnService.Password.toCharArray());
-        if (keyChainInstalled && certInstalled)
+        if (keyChainInstalled && certInstalled) {
             return;
+        }
         if (!certInstalled) {
             CertificateManager.initiateFactory(MyVpnService.CADir, MyVpnService.CAName, MyVpnService.CertName, MyVpnService.KeyType, MyVpnService.Password.toCharArray());
         }
@@ -212,7 +252,6 @@ public class MainActivity extends Activity {
         } catch (CertificateEncodingException e) {
             Logger.e(TAG, "Certificate Encoding Error", e);
         }
-
     }
 
     /**
@@ -230,12 +269,13 @@ public class MainActivity extends Activity {
         } else if (request == REQUEST_VPN) {
             if (result == RESULT_OK) {
                 Logger.d(TAG, "Starting VPN service");
+
+                showLoadingView(true);
                 mVPN.startVPN(this);
             } else {
                 buttonConnect.setChecked(false);    // update UI in case user doesn't give consent to VPN
             }
         }
-
     }
 
 

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
@@ -177,6 +177,12 @@ public class MainActivity extends Activity {
             registerReceiver(myReceiver, new IntentFilter(getString(R.string.vpn_running_broadcast_intent)));
             myReceiverIsRegistered = true;
         }
+
+        //If the VPN was started before the user closed the app and still is not running, show
+        //the loading view once again.
+        if (MyVpnService.isStarted()) {
+            showLoadingView(true);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
@@ -71,6 +71,7 @@ public class MyVpnService extends VpnService implements Runnable {
     private static final String TAG = "MyVpnService";
     private static final boolean DEBUG = true;
     private static boolean running = false;
+    private static boolean started = false;
     private static HashMap<String, Integer[]> notificationMap = new HashMap<String, Integer[]>();
 
     //The virtual network interface, get and return packets to it
@@ -103,6 +104,10 @@ public class MyVpnService extends VpnService implements Runnable {
     public static boolean isRunning() {
         /** http://stackoverflow.com/questions/600207/how-to-check-if-a-service-is-running-on-android */
         return running;
+    }
+
+    public static boolean isStarted() {
+        return started;
     }
 
     @Override
@@ -140,6 +145,7 @@ public class MyVpnService extends VpnService implements Runnable {
             return;
         }
 
+        started = false;
         running = true;
 
         //Notify the MainActivity that the VPN is now running.
@@ -325,6 +331,7 @@ public class MyVpnService extends VpnService implements Runnable {
     public void startVPN(Context context) {
         Intent intent = new Intent(context, MyVpnService.class);
         context.startService(intent);
+        started = true;
     }
 
     public void stopVPN() {

--- a/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
@@ -137,9 +137,15 @@ public class MyVpnService extends VpnService implements Runnable {
 
     @Override
     public void run() {
-        if (!(setup_network()))
+        if (!(setup_network())) {
             return;
+        }
+
         running = true;
+
+        Intent i = new Intent("com.PrivacyGuard.VpnRunning");
+        sendBroadcast(i);
+
         setup_workers();
         wait_to_close();
     }
@@ -300,7 +306,6 @@ public class MyVpnService extends VpnService implements Runnable {
 
         mNotificationManager.cancel(id);
     }
-
 
     private void stop() {
         running = false;

--- a/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Network/FakeVPN/MyVpnService.java
@@ -68,7 +68,6 @@ public class MyVpnService extends VpnService implements Runnable {
     public static final String KeyType = "PKCS12";
     public static final String Password = "";
 
-
     private static final String TAG = "MyVpnService";
     private static final boolean DEBUG = true;
     private static boolean running = false;
@@ -143,7 +142,8 @@ public class MyVpnService extends VpnService implements Runnable {
 
         running = true;
 
-        Intent i = new Intent("com.PrivacyGuard.VpnRunning");
+        //Notify the MainActivity that the VPN is now running.
+        Intent i = new Intent(getString(R.string.vpn_running_broadcast_intent));
         sendBroadcast(i);
 
         setup_workers();

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -15,55 +15,86 @@
 -->
 
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="vertical"
-              android:padding="10dp"
-    tools:context=".MainActivity"
-    android:weightSum="1">
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
 
-    <ToggleButton
+    <RelativeLayout
+        android:visibility="gone"
+        android:id="@+id/loading_view"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/connect_button"
-        android:layout_gravity="center_horizontal"
-        android:checked="false" />
+        android:layout_height="match_parent"
+        android:gravity="center">
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:gravity="center">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Currently Setting Up VPN"
+                android:textSize="25sp"
+                android:padding="10dp"/>
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true"
+                android:padding="10dp"/>
+        </LinearLayout>
+    </RelativeLayout>
 
-    <!-- <Button
-        style="@style/item"
-        android:id="@+id/connect_button"
-        android:text="@string/connect"
-        /> -->
-
-    <Button
-        android:text="Update Filter Keywords"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button"
-        android:onClick="updateFilterKeywords" />
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:weightSum="1"
+        android:id="@+id/content">
 
-    <Button
-        android:text="Export Data"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:id="@+id/button3"
-        android:onClick="exportData"/>
+        <ToggleButton
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/connect_button"
+            android:layout_gravity="center_horizontal"
+            android:checked="false" />
 
-    <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:text="Apps that have leaked information:"
-        android:textStyle="bold"
-        android:id="@+id/textView"
-        android:layout_marginTop="4dp"
-        android:layout_marginBottom="4dp"/>
+        <!-- <Button
+            style="@style/item"
+            android:id="@+id/connect_button"
+            android:text="@string/connect"
+            /> -->
 
-    <ListView android:id="@+id/leaksList"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1">
-    </ListView>
-</LinearLayout>
+        <Button
+            android:text="Update Filter Keywords"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/button"
+            android:onClick="updateFilterKeywords" />
+
+        <Button
+            android:text="Export Data"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/button3"
+            android:onClick="exportData"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center"
+            android:text="Apps that have leaked information:"
+            android:textStyle="bold"
+            android:id="@+id/textView"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp"/>
+
+        <ListView android:id="@+id/leaksList"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+        </ListView>
+    </LinearLayout>
+</RelativeLayout>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,7 +35,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Currently Setting Up VPN"
+                android:text="@string/starting_vpn_message"
                 android:textSize="25sp"
                 android:padding="10dp"/>
             <ProgressBar

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,5 +10,7 @@
     <string name="mainActivity_warn_dialog_msg">Unable to start Privacy Guard</string>
     <string name="data_leakage_frequency">Data leakage frequency this month:</string>
     <string name="title_activity_location">Map</string>
+    <string name="starting_vpn_message">Starting VPN</string>
+    <string name="vpn_running_broadcast_intent">com.PrivacyGuard.VpnRunning</string>
 
 </resources>


### PR DESCRIPTION
The MainActivity had several problems.  First of all, there were numerous ways to make it crash.  This could be resolved by simply NOT automatically starting the VPN when you open the app.  It should be left up to the user to turn the VPN on.

Second of all, a certain race condition caused the app to become unresponsive in the sense that you could toggle with VPN button to "off" without actually turning off the VPN.  This was caused because, under certain conditions, it would take up to 5 seconds for the VPN to start running.  So if a user selected to turn the VPN on and then (within 5 seconds) selected to turn it off, the app would already think the VPN was not running and hence would not do anything.  To fix this, a loading screen now appears while the VPN is starting up.  The loading screen is dismissed when the VPN is running, and the application becomes interactive once again.