### PR TITLE
Database reset bug

### DIFF
--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/LocationDetailActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/LocationDetailActivity.java
@@ -1,10 +1,10 @@
 package com.PrivacyGuard.Application.Activities;
 
-import android.app.Activity;
 import android.app.TaskStackBuilder;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
@@ -159,8 +159,16 @@ public class LocationDetailActivity extends AppCompatActivity implements OnMapRe
             }
         }
 
-        LatLngBounds bounds = builder.build();
-        map.moveCamera(CameraUpdateFactory.newLatLng(bounds.getCenter()));
+        try {
+            LatLngBounds bounds = builder.build();
+            map.moveCamera(CameraUpdateFactory.newLatLng(bounds.getCenter()));
+        } catch (IllegalArgumentException e) {
+            //If the builder in the try block above has no points added to it, an exception
+            //will be thrown. This should NEVER happen because a user should never be able to
+            //navigate to this activity if there are no location leaks. However, if it does happen,
+            //fail gracefully.
+            Log.e(e.getClass().toString(), e.getMessage());
+        }
 
         googleMap = map;
     }

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/LocationDetailActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/LocationDetailActivity.java
@@ -166,7 +166,7 @@ public class LocationDetailActivity extends AppCompatActivity implements OnMapRe
             //If the builder in the try block above has no points added to it, an exception
             //will be thrown. This should NEVER happen because a user should never be able to
             //navigate to this activity if there are no location leaks. However, if it does happen,
-            //fail gracefully.
+            //fail gracefully instead of crashing.
             Log.e(e.getClass().toString(), e.getMessage());
         }
 

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
@@ -158,7 +158,6 @@ public class MainActivity extends AppCompatActivity {
         };
 
         mDbHandler = new DatabaseHandler(this);
-        mDbHandler.monthlyReset();
     }
 
     @Override

--- a/app/src/main/java/com/PrivacyGuard/Application/Database/DatabaseHandler.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Database/DatabaseHandler.java
@@ -126,34 +126,6 @@ public class DatabaseHandler extends SQLiteOpenHelper {
         onCreate(db);
     }
 
-    //TODO: I think this resets table as soon as it goes into next month, so on the first day of a month
-    //      user would lose all data even they are from yesterday
-    public void monthlyReset() {
-        DateFormat dateFormat = new SimpleDateFormat("MM", Locale.getDefault());//TODO: get user locale
-        Date date = new Date();
-        String m = dateFormat.format(date);
-
-        SQLiteDatabase db = this.getWritableDatabase();
-
-        //reset table date_leak
-        Cursor cursor = db.query(TABLE_DATA_LEAKS, new String[]{KEY_TIME_STAMP}, null,
-                null, null, null, " date(" + KEY_TIME_STAMP + ") DESC", null);
-
-        if (cursor != null && cursor.getCount() > 0) {
-            cursor.moveToFirst();
-            String dateString = cursor.getString(0).substring(3, 5);
-
-            if (!dateString.equals(m)) {
-                resetDataLeakTable();
-                return;
-            }
-        }
-
-        if (cursor != null) {
-            cursor.close();
-        }
-    }
-
     /**
      * All CRUD(Create, Read, Update, Delete) Operations
      */


### PR DESCRIPTION
Previously, whenever the user opened the app, if any data leaks existed in the database for the previous month, the entire data leaks table would be dropped (all data leaks deleted).  However, when the data leaks were deleted, the data leak summary table was not dropped/managed accordingly. 

Thus, the following behaviour would arise:

1.) The data leak summary activity would say that there were many leaks:

![screenshot_2017-02-05-20-06-06](https://cloud.githubusercontent.com/assets/11587125/22631658/6068e6e2-ebdf-11e6-9e42-27cb3d202383.png)

2.) However, when clicking on the summary table rows to navigate to the leaks details activity, no leaks are present (because they have all been deleted from the database).

![screenshot_2017-02-05-20-06-12](https://cloud.githubusercontent.com/assets/11587125/22631664/69bf32b4-ebdf-11e6-9640-2d9e6cde0250.png)

Its unclear why all data leaks would be deleted on the first day of a new month.  I'm guessing it's to manage the database.  I think the user should have more power over managing the deletion of old leaks.  Until I can confirm what the desired functionality is, we'll just remove the broken functionality.