### PR TITLE
Results of testing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,6 @@
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
-    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-permission
         xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="com.google.android.providers.gsf.permission.READ_GSERVICES" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-permission
         xmlns:tools="http://schemas.android.com/tools"
@@ -89,6 +90,14 @@
                 <action android:name="android.net.VpnService" />
             </intent-filter>
         </service>
+
+        <receiver android:name="com.PrivacyGuard.Application.Database.RecordAppStatusEvents" >
+            <intent-filter>
+                <action android:name="android.intent.action.DATE_CHANGED" />
+                <action android:name="android.intent.action.ACTION_SHUTDOWN" />
+                <action android:name="android.intent.action.QUICKBOOT_POWEROFF" />
+            </intent-filter>
+        </receiver>
 
         <!--
              The API key for Google Maps-based APIs is defined as a string resource.

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/AllAppsDataActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/AllAppsDataActivity.java
@@ -1,6 +1,8 @@
 package com.PrivacyGuard.Application.Activities;
 
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.MenuItem;
 
 import com.PrivacyGuard.Application.Database.DatabaseHandler;
 import com.PrivacyGuard.Plugin.LeakReport;
@@ -25,5 +27,49 @@ public class AllAppsDataActivity extends DataActivity {
     @Override
     public String getAppName() {
         return "All Apps";
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch(item.getItemId()) {
+            case R.id.info:
+                AlertDialog alertDialog;
+
+                switch (tabLayout.getSelectedTabPosition()) {
+                    case 0:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_report_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.report_message_all_apps)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+
+                    case 1:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_summary_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.summary_message_all_apps)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+
+                    case 2:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_query_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.query_message_all_apps)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+                }
+
+                return false;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/AllAppsDataActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/AllAppsDataActivity.java
@@ -66,8 +66,6 @@ public class AllAppsDataActivity extends DataActivity {
                         alertDialog.show();
                         return true;
                 }
-
-                return false;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/AppDataActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/AppDataActivity.java
@@ -2,6 +2,8 @@ package com.PrivacyGuard.Application.Activities;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AlertDialog;
+import android.view.MenuItem;
 
 import com.PrivacyGuard.Application.Database.DatabaseHandler;
 import com.PrivacyGuard.Plugin.LeakReport;
@@ -41,5 +43,49 @@ public class AppDataActivity extends DataActivity {
     @Override
     public String getAppPackageName() {
         return packageName;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        switch(item.getItemId()) {
+            case R.id.info:
+                AlertDialog alertDialog;
+
+                switch (tabLayout.getSelectedTabPosition()) {
+                    case 0:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_report_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.report_message_single_app)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+
+                    case 1:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_summary_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.summary_message_single_app)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+
+                    case 2:
+                        alertDialog = new AlertDialog.Builder(this)
+                                .setTitle(R.string.leak_query_title)
+                                .setIcon(R.drawable.info_outline)
+                                .setMessage(R.string.query_message_single_app)
+                                .setPositiveButton(R.string.dialog_accept, null)
+                                .create();
+                        alertDialog.show();
+                        return true;
+                }
+
+                return false;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/AppDataActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/AppDataActivity.java
@@ -82,8 +82,6 @@ public class AppDataActivity extends DataActivity {
                         alertDialog.show();
                         return true;
                 }
-
-                return false;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/DataActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/DataActivity.java
@@ -5,24 +5,20 @@ package com.PrivacyGuard.Application.Activities;
  */
 
 import android.content.Context;
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.design.widget.TabLayout;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentPagerAdapter;
 import android.support.v4.view.ViewPager;
-import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuInflater;
-import android.view.MenuItem;
 
 import com.PrivacyGuard.Application.Database.DataLeak;
 import com.PrivacyGuard.Application.Fragments.LeakQueryFragment;
 import com.PrivacyGuard.Application.Fragments.LeakReportFragment;
 import com.PrivacyGuard.Application.Fragments.LeakSummaryFragment;
-import com.PrivacyGuard.Application.Helpers.ActivityRequestCodes;
 import com.PrivacyGuard.Application.Interfaces.AppDataInterface;
 import com.PrivacyGuard.Plugin.LeakReport;
 
@@ -41,6 +37,8 @@ public abstract class DataActivity extends AppCompatActivity implements AppDataI
     protected List<DataLeak> deviceLeaks;
     protected List<DataLeak> keywordLeaks;
 
+    protected TabLayout tabLayout;
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -55,7 +53,7 @@ public abstract class DataActivity extends AppCompatActivity implements AppDataI
         viewPager.setAdapter(new CustomFragmentPagerAdapter(getSupportFragmentManager(), this));
         viewPager.setOffscreenPageLimit(TAB_COUNT - 1);
 
-        TabLayout tabLayout = (TabLayout) findViewById(R.id.sliding_tabs);
+        tabLayout = (TabLayout) findViewById(R.id.sliding_tabs);
         tabLayout.setupWithViewPager(viewPager);
     }
 
@@ -64,22 +62,6 @@ public abstract class DataActivity extends AppCompatActivity implements AppDataI
         MenuInflater inflater = getMenuInflater();
         inflater.inflate(R.menu.app_data_menu, menu);
         return super.onCreateOptionsMenu(menu);
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch(item.getItemId()) {
-            case R.id.info:
-                AlertDialog alertDialog = new AlertDialog.Builder(this)
-                        .setTitle(R.string.leak_report_title)
-                        .setIcon(R.drawable.info_outline)
-                        .setMessage(R.string.graph_message)
-                        .setPositiveButton(R.string.dialog_accept, null)
-                        .create();
-                alertDialog.show();
-                return true;
-        }
-        return super.onOptionsItemSelected(item);
     }
 
     public class CustomFragmentPagerAdapter extends FragmentPagerAdapter {

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/DetailListViewAdapter.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/DetailListViewAdapter.java
@@ -1,6 +1,5 @@
 package com.PrivacyGuard.Application.Activities;
 
-import android.app.Activity;
 import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -76,6 +75,4 @@ public class DetailListViewAdapter extends BaseAdapter {
         public TextView content;
         public TextView time;
     }
-
-
 }

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
@@ -334,9 +334,7 @@ public class MainActivity extends AppCompatActivity {
         }
 
         Comparator<AppSummary> comparator = PreferenceHelper.getAppLeakOrder(getApplicationContext());
-        if (comparator != null) {
-            Collections.sort(apps, comparator);
-        }
+        Collections.sort(apps, comparator);
 
         if (adapter == null) {
             adapter = new MainListViewAdapter(this, apps);

--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/MainActivity.java
@@ -52,7 +52,6 @@ import android.widget.ListView;
 
 import com.PrivacyGuard.Application.Database.AppSummary;
 import com.PrivacyGuard.Application.Database.DatabaseHandler;
-import com.PrivacyGuard.Application.Database.RecordAppStatusService;
 import com.PrivacyGuard.Application.Helpers.ActivityRequestCodes;
 import com.PrivacyGuard.Application.Helpers.PermissionsHelper;
 import com.PrivacyGuard.Application.Helpers.PreferenceHelper;
@@ -204,10 +203,6 @@ public class MainActivity extends AppCompatActivity {
         // Only enable the app if all required permissions are granted.
         // Otherwise, prompt the user to grant the permissions.
         checkPermissionsAndRequestAndEnableViews();
-
-        final IntentFilter filter = new IntentFilter();
-        filter.addAction(Intent.ACTION_USER_PRESENT);
-        getApplicationContext().registerReceiver(new RecordAppStatusService(), filter);
     }
 
     /**

--- a/app/src/main/java/com/PrivacyGuard/Application/Fragments/LeakQueryFragment.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Fragments/LeakQueryFragment.java
@@ -54,7 +54,7 @@ public class LeakQueryFragment extends Fragment {
     private static final String DATE_FORMAT_DISPLAY_SPECIFIC = "h:mm:ss a, E, MMM d, yyyy";
     private static final DateFormat dateFormatDisplaySpecific = new SimpleDateFormat(DATE_FORMAT_DISPLAY_SPECIFIC, Locale.CANADA);
 
-    private ListView leaksList;
+    private ListAdapter listAdapter;
     private TextView totalNumber;
     private View progressBar;
     private ImageButton query;
@@ -79,9 +79,10 @@ public class LeakQueryFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.leak_query_fragment, null);
 
-        leaksList = (ListView)view.findViewById(R.id.list_view);
+        ListView leaksList = (ListView)view.findViewById(R.id.list_view);
         leaksList.addHeaderView(LayoutInflater.from(getContext()).inflate(R.layout.query_list_header, null, false));
-        leaksList.setAdapter(new ListAdapter(getContext(), new ArrayList<DataLeak>()));
+        listAdapter = new ListAdapter(getContext(), new ArrayList<DataLeak>());
+        leaksList.setAdapter(listAdapter);
 
         totalNumber = (TextView)view.findViewById(R.id.total_number);
         progressBar = view.findViewById(R.id.progress_bar);
@@ -155,7 +156,9 @@ public class LeakQueryFragment extends Fragment {
         query.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                leaksList.setAdapter(new ListAdapter(getContext(), new ArrayList<DataLeak>()));
+                listAdapter.clear();
+                listAdapter.notifyDataSetChanged();
+
                 totalNumber.setVisibility(View.GONE);
                 progressBar.setVisibility(View.VISIBLE);
                 query.setEnabled(false);
@@ -177,6 +180,7 @@ public class LeakQueryFragment extends Fragment {
         @Override
         public View getView(int position, View convertView, ViewGroup parent) {
             DataLeak dataLeak = getItem(position);
+
             // Check if an existing view is being reused, otherwise inflate the view
             if (convertView == null) {
                 convertView = LayoutInflater.from(getContext()).inflate(R.layout.data_leak, parent, false);
@@ -190,7 +194,7 @@ public class LeakQueryFragment extends Fragment {
             TextView statusText = (TextView)convertView.findViewById(R.id.status);
 
             String categoryCamelCase = dataLeak.getCategory().toLowerCase();
-            categoryCamelCase = categoryCamelCase.substring(0,1).toUpperCase() + categoryCamelCase.substring(1);
+            categoryCamelCase = categoryCamelCase.substring(0, 1).toUpperCase() + categoryCamelCase.substring(1);
 
             appNameText.setText(dataLeak.getAppName());
             categoryText.setText(categoryCamelCase);
@@ -258,7 +262,11 @@ public class LeakQueryFragment extends Fragment {
         @Override
         protected void onPostExecute(ArrayList<DataLeak> result) {
             totalNumber.setText(String.format("%s Results", result.size()));
-            leaksList.setAdapter(new ListAdapter(getContext(), result));
+
+            listAdapter.clear();
+            listAdapter.addAll(result);
+            listAdapter.notifyDataSetChanged();
+
             totalNumber.setVisibility(View.VISIBLE);
             progressBar.setVisibility(View.GONE);
             query.setEnabled(true);

--- a/app/src/main/java/com/PrivacyGuard/Application/Helpers/PreferenceHelper.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Helpers/PreferenceHelper.java
@@ -40,12 +40,10 @@ public class PreferenceHelper {
 
         switch (appLeakOrder) {
             case 1:
-                return null;
+                return DECREASING_ORDER_BY_NUMBER_OF_LEAKS;
             case 2:
                 return INCREASING_ORDER_BY_NUMBER_OF_LEAKS;
             case 3:
-                return DECREASING_ORDER_BY_NUMBER_OF_LEAKS;
-            case 4:
                 return ALPHABETICAL_ORDER;
             default:
                 return null;

--- a/app/src/main/java/com/PrivacyGuard/Application/Helpers/PreferenceHelper.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Helpers/PreferenceHelper.java
@@ -8,24 +8,12 @@ import com.PrivacyGuard.Application.Activities.R;
 import com.PrivacyGuard.Application.Database.AppSummary;
 
 import java.util.Comparator;
-import java.util.Date;
 
 /**
  * Created by lucas on 05/02/17.
  */
 
 public class PreferenceHelper {
-    private static final String RECORD_APP_STATUS_SERVICE_LAST_TIME_RUN = "record_app_status_service_last_time_run";
-
-    public static void setRecordAppStatusServiceLastTimeRun(Context context) {
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
-        sp.edit().putLong(RECORD_APP_STATUS_SERVICE_LAST_TIME_RUN, (new Date()).getTime()).apply();
-    }
-
-    public static long getRecordAppStatusServiceLastTimeRun(Context context) {
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
-        return sp.getLong(RECORD_APP_STATUS_SERVICE_LAST_TIME_RUN, 0);
-    }
 
     public static int getLeakReportGraphDomainSize(Context context) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -3,9 +3,8 @@
 
     <!-- Preferences -->
     <string-array name="pref_leak_display_entries">
-        <item>In order of occurrence</item>
-        <item>Increasing by # of leaks</item>
         <item>Decreasing by # of leaks</item>
+        <item>Increasing by # of leaks</item>
         <item>Alphabetical order by app name</item>
     </string-array>
 
@@ -13,7 +12,6 @@
         <item>1</item>
         <item>2</item>
         <item>3</item>
-        <item>4</item>
     </string-array>
 
     <string-array name="pref_graph_domain_size_entries">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,10 +74,10 @@
     <string name="leak_query_title">Leak Query</string>
     <string name="report_message_single_app">This graph shows when your app is leaking compared to when it is in the foreground or background. Use the navigation arrows to move forward and backward in time.</string>
     <string name="summary_message_single_app">A summary of the leaks of your app, by category and foreground status.</string>
-    <string name="query_message_single_app">Set the parameters as you wish in order to investigate what your app has been leaking.</string>
+    <string name="query_message_single_app">Set the parameters as you wish in order to investigate when and what your app has been leaking.</string>
     <string name="report_message_all_apps">This graph shows when your apps are leaking. Use the navigation arrows to move forward and backward in time.</string>
     <string name="summary_message_all_apps">A summary of the leaks of all your apps, by category and foreground status.</string>
-    <string name="query_message_all_apps">Set the parameters as you wish in order to investigate what your apps have been leaking.</string>
+    <string name="query_message_all_apps">Set the parameters as you wish in order to investigate when and what your apps have been leaking.</string>
 
 
     <!-- Spinners -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,10 +73,10 @@
     <string name="leak_summary_title">Leak Summary</string>
     <string name="leak_query_title">Leak Query</string>
     <string name="report_message_single_app">This graph shows when your app is leaking compared to when it is in the foreground or background. Use the navigation arrows to move forward and backward in time.</string>
-    <string name="summary_message_single_app">A brief summary of the leaks for your app.</string>
+    <string name="summary_message_single_app">A summary of the leaks of your app, by category and foreground status.</string>
     <string name="query_message_single_app">Set the parameters as you wish in order to investigate what your app has been leaking.</string>
     <string name="report_message_all_apps">This graph shows when your apps are leaking. Use the navigation arrows to move forward and backward in time.</string>
-    <string name="summary_message_all_apps">A brief summary of the leaks for all your apps.</string>
+    <string name="summary_message_all_apps">A summary of the leaks of all your apps, by category and foreground status.</string>
     <string name="query_message_all_apps">Set the parameters as you wish in order to investigate what your apps have been leaking.</string>
 
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -64,13 +64,21 @@
     <string name="keyword_category">Keyword</string>
 
     <!-- Android Plot Display -->
-    <string name="graph_message">This feature allows you to see when your apps are leaking compared to when the app is in the foreground or background.</string>
     <string name="dialog_accept">OK</string>
-    <string name="leak_report_title">Leak Report</string>
     <string name="app_status_foreground">Foreground</string>
     <string name="app_status_background">Background</string>
     <string name="app_status_no_data">No Data</string>
     <string name="app_data_info">Info</string>
+    <string name="leak_report_title">Leak Report</string>
+    <string name="leak_summary_title">Leak Summary</string>
+    <string name="leak_query_title">Leak Query</string>
+    <string name="report_message_single_app">This graph shows when your app is leaking compared to when it is in the foreground or background. Use the navigation arrows to move forward and backward in time.</string>
+    <string name="summary_message_single_app">A brief summary of the leaks for your app.</string>
+    <string name="query_message_single_app">Set the parameters as you wish in order to investigate what your app has been leaking.</string>
+    <string name="report_message_all_apps">This graph shows when your apps are leaking. Use the navigation arrows to move forward and backward in time.</string>
+    <string name="summary_message_all_apps">A brief summary of the leaks for all your apps.</string>
+    <string name="query_message_all_apps">Set the parameters as you wish in order to investigate what your apps have been leaking.</string>
+
 
     <!-- Spinners -->
     <string name="spinner_category">Category:</string>


### PR DESCRIPTION
The result of me testing the new features over the past week.

In summary, these were the main changes:

1.) The service that I registered previously (to record the app status events in Privacy Guard's database) was not being run properly.  Hence, foreground and background status events of leaking apps were lost.  I have now registered the service to run every time that the phone shuts down and every time that there is a date change (ie. once every day while the phone is on).  These events should be more reliable than the event that I was previously relying on.  As well, this ensures that all the data that we need will be recorded, where as before I was relying on the user to turn on the phone once every couple of days.

2.) Previously, in the tab layout screen (with the graphs), there was an info icon in the options menu that displayed a static message.  Now, the message changes depending on what tab is currently visible, and whether the displayed data is for a single app or all apps.  This explains to the user what each feature is for.

3.) Now that Privacy Guard should record all the app status events, I removed the notion of "no data" (blue background) from the graph.  Now, the background will always be green or red for foreground or background respectively.  This is important because some apps will leak without ever being opened, and should therefore be classified as background instead of "no data".

4.) I removed the "in order occurred" option from the "leak display order" setting in the settings screen.  This is because the order in which the SQLite database retrieves applications is not in the same order of the first leak occurrence of each application (perhaps it is in the order of the most recently updated application in the database).  The default is now "decreasing by # of leaks" so that higher leaking apps are displayed first.

5.) On the leak report graph, when all leaks are within one domain step of the centred leak, both navigational arrows should be disabled.  (This occurred when the domain size was very large and all the leaks were clustered on the graph.)  This change removes ambiguity. 