### PR TITLE
Results of testing round 2.

### DIFF
--- a/app/src/main/java/com/PrivacyGuard/Application/Activities/AppSummaryActivity.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Activities/AppSummaryActivity.java
@@ -142,5 +142,4 @@ public class AppSummaryActivity extends AppCompatActivity {
         }
         return super.onOptionsItemSelected(item);
     }
-
 }

--- a/app/src/main/java/com/PrivacyGuard/Application/Fragments/LeakReportFragment.java
+++ b/app/src/main/java/com/PrivacyGuard/Application/Fragments/LeakReportFragment.java
@@ -342,47 +342,23 @@ public class LeakReportFragment extends Fragment {
             SimpleXYSeries seriesForeground = new SimpleXYSeries(null);
             SimpleXYSeries seriesBackground = new SimpleXYSeries(null);
 
-            AppStatusEvent lastEvent = null;
-            AppStatusEvent firstEvent = null;
+            // At the beginning of time, the app was in the background.
+            seriesBackground.addLast(0, maxNumberOfLeaks);
+
             for (AppStatusEvent event : appStatusEventList) {
                 if (event.getForeground()) {
-                    seriesForeground.addLast(event.getTimeStamp(), 0);
                     seriesForeground.addLast(event.getTimeStamp(), maxNumberOfLeaks);
-
-                    seriesBackground.addLast(event.getTimeStamp(), maxNumberOfLeaks);
                     seriesBackground.addLast(event.getTimeStamp(), 0);
                 } else {
-                    seriesForeground.addLast(event.getTimeStamp(), maxNumberOfLeaks);
                     seriesForeground.addLast(event.getTimeStamp(), 0);
-
-                    seriesBackground.addLast(event.getTimeStamp(), 0);
                     seriesBackground.addLast(event.getTimeStamp(), maxNumberOfLeaks);
                 }
-
-                lastEvent = event;
-                if (firstEvent == null) firstEvent = event;
             }
 
-            if (firstEvent == null) {
-                // In the case that there are no status events, the app leaked without ever being opened.
-                // Hence, the app has been in the background the entire time.
-                seriesBackground.addFirst(currentTime, maxNumberOfLeaks);
-                seriesBackground.addFirst(0, maxNumberOfLeaks);
-            }
-            else {
-                // Up until the first event, the app was in the background.
-                seriesBackground.addFirst(firstEvent.getTimeStamp(), maxNumberOfLeaks);
-                seriesBackground.addFirst(0, maxNumberOfLeaks);
-            }
-
-            if (lastEvent != null) {
-                if (lastEvent.getForeground()) {
-                    throw new RuntimeException("This should not happen.");
-                }
-                else {
-                    seriesBackground.addLast(currentTime, maxNumberOfLeaks);
-                }
-            }
+            // This ensures that the last event on the graph persists to the current time.
+            // All future time on the graph does not have a background color.
+            seriesForeground.addLast(currentTime, 0);
+            seriesBackground.addLast(currentTime, 0);
 
             plot.addSeries(seriesForeground, stepFormatterForeground);
             plot.addSeries(seriesBackground, stepFormatterBackground);


### PR DESCRIPTION
1.) A bug occurred when the update task ran so quickly after the app left the foreground that the most recent status event was not yet available in the api. Hence, the leak was incorrectly classified as foreground. To fix this, run the update task after 10 seconds to ensure that the most recent status event is available.

2.) 	Fixing crash when app status events from Android api don't behave exactly as expected. Previously, I expected that foreground/background events would alternate, and that the last event would have to be a background event (because when the code is run, Privacy Guard is in the foreground). This is certainly the case most of the time. However, not 100% of the time. This could be because Android does not record these events precisely, or because the notion of foreground/background is loosely defined in the first place.